### PR TITLE
Add media file renaming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ For example:
 ```bash
 python sort_short_nort.py ~/Downloads ~/Organized --move
 ```
+
+### Media renaming
+
+When processing Photos and Videos the tool renames files based on the detected
+project or genre and the file's modification timestamp. For example an image in
+the "Vacation" category is copied as `Vacation_20240101_101500.jpg`. Other file
+types keep their original names.

--- a/sort_short_nort.py
+++ b/sort_short_nort.py
@@ -50,6 +50,14 @@ def infer_project_or_genre(file_path, file_type):
     parent = os.path.basename(os.path.dirname(file_path))
     return parent if parent else "Uncategorized"
 
+def generate_media_filename(file_path, file_type, project_or_genre):
+    ts = datetime.fromtimestamp(os.path.getmtime(file_path)).strftime("%Y%m%d_%H%M%S")
+    name, ext = os.path.splitext(os.path.basename(file_path))
+    if file_type in ("Photos", "Videos"):
+        clean_proj = project_or_genre.replace(" ", "_")
+        return f"{clean_proj}_{ts}{ext}"
+    return name + ext
+
 def move_unique_files(source_folder, dest_folder, move_files=False, dry_run=False):
     hash_dict = {}
     for root, dirs, files in os.walk(source_folder):
@@ -74,7 +82,10 @@ def move_unique_files(source_folder, dest_folder, move_files=False, dry_run=Fals
             os.makedirs(target_dir, exist_ok=True)
 
             # Handle versioning if a file with same name but different content exists
-            base_filename = filename
+            if file_type in ("Photos", "Videos"):
+                base_filename = generate_media_filename(full_path, file_type, project_or_genre)
+            else:
+                base_filename = filename
             final_path = os.path.join(target_dir, base_filename)
             version = 1
             while os.path.exists(final_path):


### PR DESCRIPTION
## Summary
- create `generate_media_filename` for renaming photos/videos
- use the helper when moving files
- document the new behaviour in the README

## Testing
- `python sort_short_nort.py sample_src sample_dest --dry-run`
- `python sort_short_nort.py sample_src sample_dest`

------
https://chatgpt.com/codex/tasks/task_e_686993ed4bdc8332b79ca447a1007347