### PR TITLE
Add fallback for project inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ When processing Photos and Videos the tool renames files based on the detected
 project or genre and the file's modification timestamp. For example an image in
 the "Vacation" category is copied as `Vacation_20240101_101500.jpg`. Other file
 types keep their original names.
+If the AI classifier doesn't return a meaningful result (empty or
+`"Uncategorized"`), the parent folder name is used instead.

--- a/sort_short_nort.py
+++ b/sort_short_nort.py
@@ -42,12 +42,21 @@ def infer_type(file_path):
         return "Other"
 
 def infer_project_or_genre(file_path, file_type):
-    # Add your custom rules for genre/project here
-    # For photos, you could run AI classifier
-    if file_type == "Photos" or file_type == "Videos":
-        return ai_classify_image(file_path)
-    # For code/art, maybe use parent folder as project
+    """Infer the project or genre for a file.
+
+    For media files we attempt AI classification first. If that result is
+    empty or ``"Uncategorized"`` we fall back to using the file's parent folder
+    name. Other file types always use the parent folder.
+    """
+
     parent = os.path.basename(os.path.dirname(file_path))
+
+    if file_type in ("Photos", "Videos"):
+        result = ai_classify_image(file_path)
+        if result and result != "Uncategorized":
+            return result
+        return parent if parent else "Uncategorized"
+
     return parent if parent else "Uncategorized"
 
 def generate_media_filename(file_path, file_type, project_or_genre):


### PR DESCRIPTION
## Summary
- store the AI classifier result when inferring project or genre
- use the parent folder as a fallback when the classifier is empty or returns `"Uncategorized"`
- document the fallback behavior in the README

## Testing
- `python -m py_compile sort_short_nort.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adf57c9308332aaf9f8d581a7c492