### PR TITLE
Add 3D file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ This project organizes files into a structured folder hierarchy. Files are
 sorted by the year they were last modified, their type (e.g. Music, Photos),
 and an inferred project or genre.
 
+### Recognized file types
+
+- **Music**: `.mp3`, `.wav`, `.flac`, `.aac`
+- **Photos**: `.jpg`, `.jpeg`, `.png`, `.gif`, `.bmp`
+- **Videos**: `.mp4`, `.mov`, `.avi`, `.mkv`
+- **Art**: `.psd`, `.ai`, `.svg`
+- **3D**: `.blend`, `.fbx`, `.obj`, `.dae`, `.3ds`, `.stl`, `.ply`, `.gltf`, `.glb`, `.rbxl`, `.rbxm`
+- **Code**: `.py`, `.js`, `.ts`, `.rb`
+- **Web**: `.html`, `.css`, `.json`, `.xml`
+- **Other**: everything else
+
 ## Setup
 
 Install the required Python packages using `requirements.txt`:

--- a/sort_short_nort.py
+++ b/sort_short_nort.py
@@ -96,6 +96,20 @@ def infer_type(file_path):
         return "Videos"
     elif ext in ['.psd', '.ai', '.svg']:
         return "Art"
+    elif ext in [
+        '.blend',
+        '.fbx',
+        '.obj',
+        '.dae',
+        '.3ds',
+        '.stl',
+        '.ply',
+        '.gltf',
+        '.glb',
+        '.rbxl',
+        '.rbxm',
+    ]:
+        return "3D"
     elif ext in ['.py', '.js', '.ts', '.rb']:
         return "Code"
     elif ext in ['.html', '.css', '.json', '.xml']:


### PR DESCRIPTION
## Summary
- recognize 3D files like `.blend`, `.fbx`, `.obj`, `.rbxl` and others
- document recognized file types in README

## Testing
- `python sort_short_nort.py --help | head -n 20`
- `python -m py_compile sort_short_nort.py && echo 'syntax OK'`

------
https://chatgpt.com/codex/tasks/task_e_686af5814af883328445b6e793ed7c9a